### PR TITLE
Fixes for concurrent mongration execution

### DIFF
--- a/src/main/java/com/kuliginstepan/mongration/Mongration.java
+++ b/src/main/java/com/kuliginstepan/mongration/Mongration.java
@@ -14,9 +14,12 @@ public class Mongration extends AbstractMongration {
 
     public Mongration(MongrationProperties properties, MongoTemplate template) {
 
-        super(new ChangeSetService(properties, template),
+        super(
+            new ChangeSetService(properties, template),
             new IndexCreatorImpl(template.getConverter().getMappingContext(), template),
-            new LockServiceImpl(properties.getChangelogsCollection(), template));
+            new LockServiceImpl(properties.getChangelogsCollection(), template),
+            properties
+        );
     }
 
     @Override

--- a/src/main/java/com/kuliginstepan/mongration/ReactiveMongration.java
+++ b/src/main/java/com/kuliginstepan/mongration/ReactiveMongration.java
@@ -13,9 +13,12 @@ import reactor.core.publisher.Mono;
 public class ReactiveMongration extends AbstractMongration {
 
     public ReactiveMongration(MongrationProperties properties, ReactiveMongoTemplate mongoTemplate) {
-        super(new ReactiveChangeSetService(properties, mongoTemplate),
+        super(
+            new ReactiveChangeSetService(properties, mongoTemplate),
             new ReactiveIndexCreatorImpl(mongoTemplate.getConverter().getMappingContext(), mongoTemplate::indexOps),
-            new ReactiveLockServiceImpl(properties.getChangelogsCollection(), mongoTemplate));
+            new ReactiveLockServiceImpl(properties.getChangelogsCollection(), mongoTemplate),
+            properties
+        );
     }
 
     @Override

--- a/src/main/java/com/kuliginstepan/mongration/configuration/MongrationProperties.java
+++ b/src/main/java/com/kuliginstepan/mongration/configuration/MongrationProperties.java
@@ -1,6 +1,7 @@
 package com.kuliginstepan.mongration.configuration;
 
 import com.kuliginstepan.mongration.AbstractMongration;
+import java.time.Duration;
 import lombok.Data;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 
@@ -28,4 +29,14 @@ public class MongrationProperties {
      * Mode for running changesets
      */
     private MongrationMode mode = MongrationMode.AUTO;
+
+    /**
+     * Retry count for acquiring mongration lock
+     */
+    private int retryCount = 0;
+
+    /**
+     * Delay between retries on acquiring mongration lock
+     */
+    private Duration retryDelay = Duration.ofSeconds(4);
 }

--- a/src/main/java/com/kuliginstepan/mongration/service/impl/ReactiveLockServiceImpl.java
+++ b/src/main/java/com/kuliginstepan/mongration/service/impl/ReactiveLockServiceImpl.java
@@ -6,9 +6,11 @@ import static org.springframework.data.mongodb.core.query.Query.query;
 import com.kuliginstepan.mongration.MongrationException;
 import com.kuliginstepan.mongration.service.LockService;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.mongodb.core.ReactiveMongoTemplate;
 import reactor.core.publisher.Mono;
 
+@Slf4j
 @RequiredArgsConstructor
 public class ReactiveLockServiceImpl implements LockService {
 
@@ -19,11 +21,19 @@ public class ReactiveLockServiceImpl implements LockService {
     public Mono<Void> acquireLock() {
         return template.insert(LOCK, lockCollection)
             .onErrorMap(t -> new MongrationException("Mongration couldn't acquire process lock", t))
-            .then();
+            .then(Mono.defer(() -> {
+                log.trace("Mongration acquired process lock");
+                return Mono.empty();
+            }));
     }
 
     @Override
     public Mono<Void> releaseLock() {
-        return template.remove(query(where("_id").is(LOCK.get("_id"))), lockCollection).then();
+        return template.remove(query(where("_id").is(LOCK.get("_id"))), lockCollection)
+            .onErrorMap(t -> new MongrationException("Mongration couldn't release process lock", t))
+            .then(Mono.defer(() -> {
+                log.trace("Mongration released process lock");
+                return Mono.empty();
+            }));
     }
 }

--- a/src/test/java/com/kuliginstepan/mongration/AbstractMongrationTest.java
+++ b/src/test/java/com/kuliginstepan/mongration/AbstractMongrationTest.java
@@ -1,0 +1,108 @@
+package com.kuliginstepan.mongration;
+
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.doReturn;
+
+import com.kuliginstepan.mongration.configuration.MongrationProperties;
+import com.kuliginstepan.mongration.service.AbstractChangeSetService;
+import com.kuliginstepan.mongration.service.IndexCreator;
+import com.kuliginstepan.mongration.service.LockService;
+import java.lang.reflect.Method;
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.Spy;
+import org.mockito.junit.jupiter.MockitoExtension;
+import reactor.core.publisher.Mono;
+
+@ExtendWith(MockitoExtension.class)
+class AbstractMongrationTest {
+
+    @Spy
+    private MongrationProperties properties;
+
+    @Mock
+    private LockService lockService;
+
+    @InjectMocks
+    private FakeMongration mongration;
+
+    @Test
+    void shouldSuppressLockReleasingExceptionsIfMigrationFailed() {
+        // given
+        String actionErrorMessage = "Sample error!";
+        MongrationException releaseLockException = new MongrationException("Failed releasing lock!");
+
+        // given mocked
+        doReturn(Mono.empty()).when(lockService).acquireLock();
+        doReturn(Mono.error(releaseLockException))
+            .when(lockService).releaseLock();
+
+        // when
+        RuntimeException exception = assertThrows(RuntimeException.class, () ->
+            mongration.withLockAcquired(Mono.error(new RuntimeException(actionErrorMessage))).subscribe()
+        );
+
+        // then
+        Assertions.assertThat(exception.getCause())
+            .hasMessage(actionErrorMessage)
+            .hasSuppressedException(releaseLockException);
+    }
+
+    @Test
+    void shouldRetryLockAcquiringOnMongrationExceptions() {
+        // given
+        properties.setRetryCount(1);
+
+        // given mocked
+        doReturn(
+            Mono.error(new MongrationException("Let's fail first try!")),
+            Mono.empty()
+        ).when(lockService).acquireLock();
+
+        // when
+        mongration.acquireLock().subscribe();
+
+        // then no exception thrown
+    }
+
+    @Test
+    void shouldNotRetryLockAcquiringOnOtherExceptions() {
+        // given
+        String errorMessage = "Let's fail first try!";
+        properties.setRetryCount(1);
+
+        // given mocked
+        doReturn(
+            Mono.error(new RuntimeException(errorMessage)),
+            Mono.empty()
+        ).when(lockService).acquireLock();
+
+        // when
+        RuntimeException exception = assertThrows(RuntimeException.class, () ->
+            mongration.acquireLock().subscribe()
+        );
+
+        // then
+        Assertions.assertThat(exception.getCause())
+            .hasMessage(errorMessage);
+    }
+
+    private static class FakeMongration extends AbstractMongration {
+
+        public FakeMongration(AbstractChangeSetService changesetService,
+            IndexCreator indexCreator,
+            LockService lockService,
+            MongrationProperties properties
+        ) {
+            super(changesetService, indexCreator, lockService, properties);
+        }
+
+        @Override
+        protected Mono<Object> executeChangeSetMethod(Object changelog, Method changesetMethod) {
+            return null;
+        }
+    }
+}

--- a/src/test/java/com/kuliginstepan/mongration/ReactiveMongrationTest.java
+++ b/src/test/java/com/kuliginstepan/mongration/ReactiveMongrationTest.java
@@ -9,7 +9,6 @@ import com.kuliginstepan.mongration.annotation.Changelog;
 import com.kuliginstepan.mongration.annotation.Changeset;
 import com.kuliginstepan.mongration.configuration.MongrationAutoConfiguration;
 import com.kuliginstepan.mongration.entity.ChangesetEntity;
-import lombok.SneakyThrows;
 import org.bson.Document;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
@@ -19,6 +18,7 @@ import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
 import org.springframework.boot.autoconfigure.ImportAutoConfiguration;
 import org.springframework.boot.test.autoconfigure.data.mongo.DataMongoTest;
 import org.springframework.context.annotation.Import;
+import org.springframework.core.annotation.Order;
 import org.springframework.data.annotation.Id;
 import org.springframework.data.mongodb.core.ReactiveMongoTemplate;
 import org.springframework.data.mongodb.core.index.Indexed;
@@ -29,80 +29,13 @@ import reactor.core.publisher.Mono;
 @DataMongoTest(properties = {
     "mongration.mode=reactive",
     "mongration.changelogsCollection=test_collection",
-    "spring.data.mongodb.auto-index-creation=false"
+    "spring.data.mongodb.auto-index-creation=false",
+    "logging.level.com.kuliginstepan.mongration=TRACE"
 })
 @EnableAutoConfiguration
 @ImportAutoConfiguration(MongrationAutoConfiguration.class)
 @Import({TestChangeLog.class, TestChangeLog1.class, TestChangeLog2.class})
 class ReactiveMongrationTest extends MongoIntegrationTest {
-
-    @Changelog
-    public static class TestChangeLog {
-
-        @Changeset(author = "Stepan", order = 1)
-        public Mono<Void> testChangeSet(ReactiveMongoTemplate template) {
-            return template.findById("LOCK", Document.class, "test_collection")
-                .hasElement()
-                .flatMap(hasElement -> {
-                    assertThat(hasElement).isTrue();
-                    return template.indexOps(MongrationTest.TestDocument.class).getIndexInfo()
-                        .hasElements()
-                        .flatMap(it -> {
-                            assertThat(it).isFalse();
-                            return template.save(new Document("key", "value"), "test").then();
-                        });
-                });
-        }
-
-    }
-    @Changelog
-    public static class TestChangeLog1 {
-
-        @Changeset(author = "Stepan", order = 1)
-        public Mono<Void> testChangeSet(ReactiveMongoTemplate template) {
-            return template.findById("LOCK", Document.class, "test_collection")
-                .hasElement()
-                .flatMap(hasElement -> {
-                    assertThat(hasElement).isTrue();
-                    return template.indexOps(MongrationTest.TestDocument.class).getIndexInfo()
-                        .hasElements()
-                        .flatMap(it -> {
-                            assertThat(it).isFalse();
-                            return template.save(new Document("key", "value"), "test").then();
-                        });
-                });
-        }
-
-    }
-
-    @Changelog
-    public static class TestChangeLog2 {
-
-        @Changeset(author = "Stepan", order = 1)
-        public Mono<Void> testChangeSet(ReactiveMongoTemplate template) {
-            return template.findById("LOCK", Document.class, "test_collection")
-                .hasElement()
-                .flatMap(hasElement -> {
-                    assertThat(hasElement).isTrue();
-                    return template.indexOps(MongrationTest.TestDocument.class).getIndexInfo()
-                        .hasElements()
-                        .flatMap(it -> {
-                            assertThat(it).isFalse();
-                            return template.save(new Document("key", "value"), "test").then();
-                        });
-                });
-        }
-
-    }
-
-    @org.springframework.data.mongodb.core.mapping.Document
-    public static class TestDocument {
-
-        @Id
-        private String id;
-        @Indexed(unique = true)
-        private String index;
-    }
 
     @Autowired
     private ReactiveMongoTemplate template;
@@ -133,5 +66,77 @@ class ReactiveMongrationTest extends MongoIntegrationTest {
         template.dropCollection("test_collection").block();
         template.dropCollection("test").block();
         template.dropCollection(TestDocument.class).block();
+    }
+
+    @Order(1)
+    @Changelog
+    public static class TestChangeLog {
+
+        @Changeset(author = "Stepan", order = 1)
+        public Mono<Void> testChangeSet(ReactiveMongoTemplate template) {
+            return template.findById("LOCK", Document.class, "test_collection")
+                .hasElement()
+                .flatMap(hasElement -> {
+                    assertThat(hasElement).isTrue();
+                    return template.indexOps(MongrationTest.TestDocument.class).getIndexInfo()
+                        .hasElements()
+                        .flatMap(it -> {
+                            assertThat(it).isFalse();
+                            return template.save(new Document("key", "value"), "test").then();
+                        });
+                });
+        }
+
+    }
+
+    @Order(2)
+    @Changelog
+    public static class TestChangeLog1 {
+
+        @Changeset(author = "Stepan", order = 1)
+        public Mono<Void> testChangeSet(ReactiveMongoTemplate template) {
+            return template.findById("LOCK", Document.class, "test_collection")
+                .hasElement()
+                .flatMap(hasElement -> {
+                    assertThat(hasElement).isTrue();
+                    return template.indexOps(MongrationTest.TestDocument.class).getIndexInfo()
+                        .hasElements()
+                        .flatMap(it -> {
+                            assertThat(it).isFalse();
+                            return template.save(new Document("key", "value"), "test").then();
+                        });
+                });
+        }
+
+    }
+
+    @Order(3)
+    @Changelog
+    public static class TestChangeLog2 {
+
+        @Changeset(author = "Stepan", order = 1)
+        public Mono<Void> testChangeSet(ReactiveMongoTemplate template) {
+            return template.findById("LOCK", Document.class, "test_collection")
+                .hasElement()
+                .flatMap(hasElement -> {
+                    assertThat(hasElement).isTrue();
+                    return template.indexOps(MongrationTest.TestDocument.class).getIndexInfo()
+                        .hasElements()
+                        .flatMap(it -> {
+                            assertThat(it).isFalse();
+                            return template.save(new Document("key", "value"), "test").then();
+                        });
+                });
+        }
+
+    }
+
+    @org.springframework.data.mongodb.core.mapping.Document
+    public static class TestDocument {
+
+        @Id
+        private String id;
+        @Indexed(unique = true)
+        private String index;
     }
 }

--- a/src/test/java/com/kuliginstepan/mongration/concurrent/ConcurrentMongrationTest.java
+++ b/src/test/java/com/kuliginstepan/mongration/concurrent/ConcurrentMongrationTest.java
@@ -1,0 +1,263 @@
+package com.kuliginstepan.mongration.concurrent;
+
+import static com.kuliginstepan.mongration.concurrent.ConcurrentMongrationTest.HighlyScaledApp.APP_NAME;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.springframework.data.mongodb.core.query.Criteria.where;
+import static org.springframework.data.mongodb.core.query.Query.query;
+import static org.springframework.data.mongodb.core.query.Update.update;
+
+import com.kuliginstepan.mongration.MongoIntegrationTest;
+import com.kuliginstepan.mongration.ReactiveMongration;
+import com.kuliginstepan.mongration.annotation.Changelog;
+import com.kuliginstepan.mongration.annotation.Changeset;
+import com.kuliginstepan.mongration.configuration.MongrationProperties;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicReference;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.boot.builder.SpringApplicationBuilder;
+import org.springframework.boot.context.event.ApplicationReadyEvent;
+import org.springframework.boot.test.autoconfigure.data.mongo.DataMongoTest;
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.context.ConfigurableApplicationContext;
+import org.springframework.data.annotation.Version;
+import org.springframework.data.mongodb.core.ReactiveMongoTemplate;
+import org.springframework.data.mongodb.core.index.Indexed;
+import org.springframework.data.mongodb.core.mapping.Document;
+import org.springframework.stereotype.Component;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+import reactor.core.publisher.Mono;
+import reactor.core.scheduler.Schedulers;
+
+@Slf4j
+@ExtendWith(SpringExtension.class)
+@DataMongoTest
+@EnableAutoConfiguration(exclude = ConcurrentMongrationTest.HighlyScaledApp.class)
+class ConcurrentMongrationTest extends MongoIntegrationTest {
+
+    public static final String NODE_1 = "node-1";
+    public static final String NODE_2 = "node-2";
+    public static final String NODE_3 = "node-3";
+    public static final Map<String, NodeContext> nodesMap = Map.of(
+        NODE_1, new NodeContext(NODE_1),
+        NODE_2, new NodeContext(NODE_2),
+        NODE_3, new NodeContext(NODE_3)
+    );
+    private static final String CHANGELOG_COLLECTION = "changelogs";
+    private static final int RETRY_COUNT = 12;
+
+    @Autowired
+    private ReactiveMongoTemplate template;
+
+    @AfterEach
+    void tearDown() {
+        template.dropCollection(CHANGELOG_COLLECTION).block();
+        template.dropCollection(TestAppInfo.class).block();
+    }
+
+    @Test
+    void shouldGuardMongrationProcessWithLock() {
+        try {
+            Mono.zip(
+                runNode(NODE_1),
+                runNode(NODE_2),
+                runNode(NODE_3)
+            )
+                .subscribe(tuple ->
+                    log.info("Finished running 3 app nodes: {}", tuple)
+                );
+
+            NodeContext node1 = nodesMap.get(NODE_1);
+            NodeContext node2 = nodesMap.get(NODE_2);
+            NodeContext node3 = nodesMap.get(NODE_3);
+            nodesMap.forEach((node, ctx) -> log.info("{}: {}", node, ctx));
+
+            // wait nodes to be ready to mongrate
+            await(node1.mongrationIsReadyToStart);
+            await(node2.mongrationIsReadyToStart);
+            await(node3.mongrationIsReadyToStart);
+
+            // execute node 1 changeset and suspend
+            node1.shouldPerformMongration.countDown();
+            await(node1.executionPerformed);
+
+            // allow node 2 mongration
+            node2.shouldPerformMongration.countDown();
+            node2.shouldFinishExecution.countDown();
+
+            // ensure node 2 waits node 1 to finish
+            await(node2.mongrationFinished, false, 5);
+
+            // finish node 1 changeset to unblock node 2
+            node1.shouldFinishExecution.countDown();
+
+            // ensure node 2 skipped mongration since no changes
+            await(node2.mongrationFinished);
+            await(node2.executionPerformed, false, 1);
+
+            // allow node 3 mongration
+            node3.shouldPerformMongration.countDown();
+            node3.shouldFinishExecution.countDown();
+
+            // ensure node 3 skipped mongration since no changes
+            await(node3.mongrationFinished);
+            await(node3.executionPerformed, false, 1);
+
+            // verify only node 1 changeset is executed
+            assertThat(template.findAll(TestAppInfo.class).collectList().block())
+                .hasSize(1)
+                .containsOnlyElementsOf(List.of(new TestAppInfo(APP_NAME, "node-1", 1)));
+        } catch (IllegalStateException e) {
+            if (e.getMessage().startsWith("Latch should")) {
+                nodesMap.forEach((node, ctx) -> {
+                    if (ctx.throwableRef.get() != null) {
+                        IllegalStateException wrappedException = new IllegalStateException(String.format(
+                            "App node `%s` finished with error!", node
+                        ), ctx.throwableRef.get());
+                        wrappedException.addSuppressed(e);
+                        throw wrappedException;
+                    }
+                });
+            }
+            throw e;
+        }
+    }
+
+    private Mono<Optional<ConfigurableApplicationContext>> runNode(String node) {
+        log.info("Starting app node: {}", node);
+        return Mono.fromCallable(() ->
+            new SpringApplicationBuilder(HighlyScaledApp.class)
+                .initializers(new Initializer())
+                .properties(
+                    "mongration.mode=reactive",
+                    "mongration.changelogsCollection=" + CHANGELOG_COLLECTION,
+                    "mongration.retryDelay=1s",
+                    "mongration.retryCount=" + RETRY_COUNT,
+                    "spring.data.mongodb.auto-index-creation=false",
+                    "node=" + node,
+                    "logging.level.com.kuliginstepan.mongration=TRACE"
+                )
+                .profiles(node)
+                .run()
+        )
+            .subscribeOn(Schedulers.elastic())
+            .map(context -> {
+                log.info("App node `{}` finished successfully.", node);
+                return Optional.of(context);
+            })
+            .onErrorResume(throwable -> {
+                log.error("App node `{}` finished with error!", node, throwable);
+                nodesMap.get(node).throwableRef.set(throwable);
+                return Mono.just(Optional.empty());
+            });
+    }
+
+    static void await(CountDownLatch latch) {
+        await(latch, true, RETRY_COUNT);
+    }
+
+    static void await(CountDownLatch latch, boolean shouldPass, long seconds) {
+        try {
+            if (latch.await(seconds, TimeUnit.SECONDS) != shouldPass) {
+                throw new IllegalStateException(String.format(
+                    "Latch should%s pass in %s seconds: %s", shouldPass ? "" : "n't", seconds, latch
+                ));
+            }
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            log.warn("Interrupted during waiting for a permission to execute changeset!", e);
+        }
+    }
+
+    @TestConfiguration
+    @SpringBootApplication
+    public static class HighlyScaledApp {
+
+        public static final String APP_NAME = "highly_scaled_app";
+    }
+
+    @Component
+    public static class SpyingReactiveMongration extends ReactiveMongration {
+
+        @Value("${node}")
+        private String node;
+
+        public SpyingReactiveMongration(MongrationProperties properties, ReactiveMongoTemplate mongoTemplate) {
+            super(properties, mongoTemplate);
+        }
+
+        @Override
+        public void start(ApplicationReadyEvent event) {
+            NodeContext nodeContext = nodesMap.get(node);
+            nodeContext.mongrationIsReadyToStart.countDown();
+            await(nodeContext.shouldPerformMongration);
+
+            super.start(event);
+            nodeContext.mongrationFinished.countDown();
+        }
+    }
+
+    @Changelog
+    public static class TestChangeLog {
+
+        @Value("${node}")
+        private String node;
+
+        @Changeset(author = "Evgenii", order = 1)
+        public Mono<Void> maliciousNonIdempotentChangeSet(ReactiveMongoTemplate template) {
+            log.info("Executing changeset");
+            NodeContext nodeContext = nodesMap.get(node);
+            return template.upsert(
+                query(where("name").is(APP_NAME)),
+                update("masterNode", node),
+                TestAppInfo.class
+            )
+                .doOnSuccess(updateResult -> {
+                    nodeContext.executionPerformed.countDown();
+                    await(nodeContext.shouldFinishExecution);
+                })
+                .doFinally(signalType -> {
+                    log.info("Executing changeset: done");
+                })
+                .then();
+        }
+    }
+
+    @Data
+    @NoArgsConstructor
+    @AllArgsConstructor
+    @Document
+    public static class TestAppInfo {
+
+        @Indexed(unique = true)
+        private String name;
+        private String masterNode;
+        @Version
+        private long version;
+    }
+
+    @Data
+    public static class NodeContext {
+
+        private final String node;
+        private final CountDownLatch mongrationIsReadyToStart = new CountDownLatch(1);
+        private final CountDownLatch shouldPerformMongration = new CountDownLatch(1);
+        private final CountDownLatch executionPerformed = new CountDownLatch(1);
+        private final CountDownLatch shouldFinishExecution = new CountDownLatch(1);
+        private final CountDownLatch mongrationFinished = new CountDownLatch(1);
+        private final AtomicReference<Throwable> throwableRef = new AtomicReference<>();
+    }
+}


### PR DESCRIPTION
Addressed concurrent execution issues:
- releasing not owned lock (node 2 fails to acquire the lock but releases it)
- inconsistent detection of executed changesets in concurrent environment
- nodes fail when couldn't acquire lock which prevents from scaling nodes more then 1 at a time

3rd issue was solved by adding retry possibility so that nodes could wait their turn to execute mongration.